### PR TITLE
Fix portal message DOM injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
         portalMessage.style.padding = '5px 10px';
         portalMessage.style.borderRadius = '5px';
         portalMessage.style.transition = 'opacity 2s';
-        portalMessage.innerHTML = `Welcome, ${window.portalParams.username || 'Space Traveler'}! Return portal activated.`;
+        portalMessage.textContent = `Welcome, ${window.portalParams.username || 'Space Traveler'}! Return portal activated.`;
         
         document.body.appendChild(portalMessage);
         


### PR DESCRIPTION
## Summary
- use `textContent` instead of `innerHTML` when displaying the portal welcome message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843db357f2c832a990c9597c28aea31